### PR TITLE
Renderのデータベースをmigrateする

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# exit on error
+set -o errexit
+
+bundle install
+bundle exec rake assets:precompile
+bundle exec rake assets:clean
+bundle exec rake db:migrate


### PR DESCRIPTION
## 変更の概要
Renderのデータベースをmigrateする記述追加

## やったこと
Renderのエラーがマイグレーションが本番環境で実行されていないことに起因するようだったので参考を見ながら実施した。

## 参考
[Renderでのデプロイが失敗した時の確認](https://qiita.com/hashioga2017/items/b69cb070c0073e9c26c7)