### PR TITLE
目標設定エラー修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,12 +12,18 @@ class ApplicationController < ActionController::Base
 
   private
   def require_goal_setup
-    return if controller_name == "goals" && %w[new create edit update].include?(action_name)
-    return if controller_path == "devise/sessions" && action_name == "destroy"
+    # Deviseのログアウト時は許可
+  return if controller_path == "devise/sessions" && action_name == "destroy"
+
+  # goal#newまたはcreateアクションの場合は許可
+  if controller_name == "goals" && %w[new create].include?(action_name)
+    return
+  end
 
     goal = current_user.goal
+    # 目標が存在しない、または goal/contentが未入力なら、編集ページ含めすべて制限
     if goal.blank? || goal.goal.blank? || goal.content.blank?
-      redirect_to new_goal_path
+      redirect_to new_goal_path, danger: t("goals.flash_message.setup_required")
     end
   end
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -6,6 +6,7 @@ ja:
       create_failure: "ストレッチ目標を設定できませんでした。"
       update_success: "ストレッチ目標を更新しました。"
       update_failure: "ストレッチ目標を更新できませんでした。"
+      setup_required: "最初にストレッチ目標を設定してください。"
   boards:
     flash_message:
       create_success: "投稿が完了しました。"


### PR DESCRIPTION
## 変更の概要
ストレッチ目標設定をしない状態で目標編集ページに遷移するとブラウザでメソッドエラーが出たため、そもそも遷移できないよう修正。