### PR TITLE
画像添付を非表示

### DIFF
--- a/app/views/boards/_form.html.erb
+++ b/app/views/boards/_form.html.erb
@@ -47,6 +47,7 @@
     </div>
 
     <!-- 画像アップロード -->
+    <!--
     <div>
       <%= f.label :image, "画像（1MB以下、JPG/PNG/WebP対応）", class: "my-label-title" %>
       <%= f.file_field :image, accept: 'image/jpeg,image/png,image/webp', class: "block w-full text-sm border border-stone-300 rounded-md cursor-pointer px-2 py-2" %>
@@ -56,6 +57,7 @@
         <% end %>
       <% end %>
     </div>
+    -->
 
     <!-- 送信ボタン -->
     <div class="flex  justify-center">


### PR DESCRIPTION
## 変更の概要
画像投稿機能でプライバシー関連に関して構想しきれていないので一旦非表示。