### PR TITLE
LINE連携解除でline_messagingも削除

### DIFF
--- a/app/views/reminder_settings/show.html.erb
+++ b/app/views/reminder_settings/show.html.erb
@@ -30,7 +30,7 @@
           </div>
           <div class="ml-3">
             <p class="text-sm text-blue-700">
-              <strong>重要:</strong> 通知を受け取るには、下記より公式LINEアカウントを友達追加して公式からの連携用リンクをクリックしてください。
+              <strong>重要:</strong> 通知を受け取るには、下記より公式LINEアカウントを友達追加して公式からの連携用リンク（30分有効）を開いてください。
             </p>
             <div class="mt-4">
               <a href="https://lin.ee/94Pvk7t" target="_blank"><img src="https://scdn.line-apps.com/n/line_add_friends/btn/ja.png" alt="友だち追加" class="w-50"></a>
@@ -83,7 +83,7 @@
         <h3 class="font-medium mb-2">LINE連携について</h3>
         <ul class="list-disc list-inside space-y-1">
           <li>3日間投稿がない場合に、毎朝7時にリマインド通知をお送りします</li>
-          <li>LINE連携後、公式LINEアカウントを友達追加してください</li>
+          <li>LINE連携後、公式LINEアカウントを友達追加して送信された連携用リンク（30分有効）を開いてください</li>
         </ul>
       </div>
     <% end %>


### PR DESCRIPTION
## やったこと
LINE連携解除時にログイン用の provider: 'line' と通知用の provider: 'line_messaging' の両方を削除し、通知設定も無効化するようにコントローラを編集