### PR TITLE
マイグレートをStart Commandに変更

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -5,4 +5,3 @@ set -o errexit
 bundle install
 bundle exec rake assets:precompile
 bundle exec rake assets:clean
-bundle exec rake db:migrate


### PR DESCRIPTION
## やったこと
今回のusers.is_deleted が無いというエラーLogは本番DBにマイグレーションが未反映なためである可能性が高い。bin/render-build.shにdb:migrateがあっても、Renderの「Build」段階ではDBに接続できず実行されないことがあるためStart Commandをbundle exec rails db:migrate && bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RAILS_ENV:-production}に変更。