### PR TITLE
LINE連携完了の遷移先指定

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -18,6 +18,9 @@ class Users::SessionsController < Devise::SessionsController
 
         # LINE連携処理を実行
         complete_line_link(user, token)
+
+        # 連携完了後はreminder_settingsにリダイレクト
+        redirect_to reminder_settings_path and return
       end
     end
   end

--- a/app/views/reminder_settings/show.html.erb
+++ b/app/views/reminder_settings/show.html.erb
@@ -50,7 +50,7 @@
         <h3 class="text-lg font-semibold mb-4">公式LINEアカウントを友達追加</h3>
         <p class="text-sm text-stone-600 mb-4">
           友達追加後、公式から連携用リンク（30分有効）が送信されます。<br>
-          そのリンクを<strong>アプリにログインしているブラウザ</strong>で開いてください
+          そのリンクを開き、ログイン後に連携が完了します。
         </p>
         <div class="mb-4">
           <a href="https://lin.ee/94Pvk7t" target="_blank" class="inline-block">

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,7 +2,7 @@
 :scheduler:
   :schedule:
     check_inactive_users:
-      cron: '13 12 * * *'
+      cron: '0 7 * * *'
       class: CheckInactiveUsersJob
     sitemap_update:
       cron: '0 2 * * *'


### PR DESCRIPTION
## やったこと
・LINE連携完了の遷移先をデバイスに関わらずリマインダー設定ページに指定
・通知時刻を7時に戻した。