### PR TITLE
メール確認の有効期限変更

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,6 @@
 
 <p><%= t('devise.mailer.confirmation_instructions.instruction') %></p>
 
+<p><%= t('devise.mailer.confirmation_instructions.instruction2') %></p>
+
 <%= link_to 'メールアドレス確認を完了する', user_confirmation_url(confirmation_token: @token) %>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -9,3 +9,4 @@
 
 <p><%= t('devise.mailer.reset_password_instructions.instruction_2') %></p>
 <p><%= t('devise.mailer.reset_password_instructions.instruction_3') %></p>
+<p><%= t('devise.mailer.reset_password_instructions.instruction_4') %></p>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -229,7 +229,7 @@ Devise.setup do |config|
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
-  config.reset_password_within = 6.hours
+  config.reset_password_within = 15.minutes
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -19,12 +19,14 @@ ja:
         action: "アカウント確認"
         greeting: "こんにちは、%{recipient}さん!"
         instruction: "以下のリンクをクリックして、メールアドレスの本人確認を完了してください。あなたが希望していない場合、このメールは無視してください。"
+        instruction2: "※リンクの有効期限は15分間です。その間に確認を完了させてください。"
       reset_password_instructions:
         action: "パスワード変更"
         greeting: "こんにちは、%{recipient}さん!"
         instruction: "誰かがパスワードの再設定を希望しました。次のリンクでパスワードの再設定ができます。"
         instruction_2: "あなたが希望していない場合、このメールは無視してください。"
         instruction_3: "上のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。"
+        instruction_4: "※リンクの有効期限は15分間です。その間に変更を完了させてください。"
       unlock_instructions:
         action: "アカウントのロック解除"
         greeting: "こんにちは、%{recipient}さん!"


### PR DESCRIPTION
## 変更の概要
新規登録とパスワード変更の際のメールに記載されたリンクを有効期限15分に変更